### PR TITLE
[*] Fix: bug with brest throwing 'RangeError: Maximum call stack size ex...

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -80,8 +80,7 @@ function send(res, data, options){
  * @param {Object} res http response object
  * @param {Object} rd resource data
  */
-function callHandler(req, res, rd){
-
+function callHandler(req, res, rd){    
     /**
      * Either no authorisation is required or user is authorised
      */
@@ -181,8 +180,7 @@ module.exports.bind = function(app, noun, r){
                     if (rd.stub) {
                         send(res, {Stub: "Not implemented yet!"});
                         return;
-                    }
-
+                    }                    
 
                     req.filters = {};
 
@@ -257,20 +255,24 @@ module.exports.bind = function(app, noun, r){
 
     }
 
-    _.each(APIres,function(resourse,uri){
-        var usedMethods = _.keys(resourse);
-        var strayMethods = _.difference(verbs, usedMethods);
+    return true;
+};
 
-        var errHandler = function(req,res){
+
+module.exports.stubStrayMethods = function (app) {
+    _.each(APIres, function (resourse, uri) {
+        var usedMethods = _.keys(resourse);
+
+        var strayMethods = _.difference(verbs, usedMethods);
+        var errHandler = function (req, res) {
             res.statusCode = ec.METHOD_NOT_SUPPORTED;
             res.setHeader('Allow', usedMethods.join());
             res.send();
         };
 
-        for (var i=0; i < strayMethods.length; i++){
-            app[strayMethods[i].toLowerCase()](uri,errHandler);
+        for (var k = 0; k < strayMethods.length; k++) {
+            app[strayMethods[k].toLowerCase()](uri, errHandler);
         }
     });
 
-    return true;
-};
+}

--- a/lib/brest.js
+++ b/lib/brest.js
@@ -18,7 +18,7 @@ module.exports = function (app, settings) {
 
     API.init(settings);
 
-    for (i=0; i<resources.length; i++)
+    for (var i=0; i<resources.length; i++)
     {
         var resource = resources[i];
 
@@ -29,4 +29,5 @@ module.exports = function (app, settings) {
             console.log("Failed to initialize API resource",resource,e);
         }
     }
+    API.stubStrayMethods(app);
 };


### PR DESCRIPTION
...ceeded' error, when there are a lot of API method added to router

[*] Fix: bug with brest throwing 'RangeError: Maximum call stack size
exceeded' error, when there are a lot of API method added to router
